### PR TITLE
Fix a few mis-spacings:

### DIFF
--- a/SRD5.1-CCBY4.0License-TT.txt
+++ b/SRD5.1-CCBY4.0License-TT.txt
@@ -9646,12 +9646,12 @@ Type
 A monster’s type speaks to its fundamental nature. Certain spells, magic items, class features, and other effects in the game interact in special ways with creatures of a particular type. For example, an arrow of dragon slaying deals extra damage not only to dragons but also other creatures of the dragon type, such as dragon turtles and wyverns.  The game includes the following monster types, which have no rules of their own.
 Aberrations are utterly alien beings. Many of them have innate magical abilities drawn from the creature’s alien mind rather than the mystical forces of the world. The quintessential aberrations are aboleths, beholders, mind flayers, and slaadi.
 Beasts are nonhumanoid creatures that are a natural part of the fantasy ecology. Some of them have magical powers, but most are unintelligent and lack any society or language. Beasts include all varieties of ordinary animals, dinosaurs, and giant versions of animals.
-Celestialsare creatures native to the Upper Planes. Many of them are the servants of deities, employed as messengers or agents in the mortal realm and throughout the planes. Celestials are good by nature, so the exceptional celestial who strays from a good alignment is a horrifying rarity. Celestials include angels, couatls, and pegasi.
-Constructsare made, not born. Some are programmed by their creators to follow a simple set of instructions, while others are imbued with sentience and capable of independent thought. Golems are the iconic constructs. Many creatures native to the outer plane of Mechanus, such as modrons, are constructs shaped from the raw material of the plane by the will of more powerful creatures.
-Dragonsare large reptilian creatures of ancient origin and tremendous power. True dragons, including the good metallic dragons and the evil chromatic dragons, are highly intelligent and have innate magic. Also in this category are creatures distantly related to true dragons, but less powerful, less intelligent, and less magical, such as wyverns and pseudodragons.
+Celestials are creatures native to the Upper Planes. Many of them are the servants of deities, employed as messengers or agents in the mortal realm and throughout the planes. Celestials are good by nature, so the exceptional celestial who strays from a good alignment is a horrifying rarity. Celestials include angels, couatls, and pegasi.
+Constructs are made, not born. Some are programmed by their creators to follow a simple set of instructions, while others are imbued with sentience and capable of independent thought. Golems are the iconic constructs. Many creatures native to the outer plane of Mechanus, such as modrons, are constructs shaped from the raw material of the plane by the will of more powerful creatures.
+Dragons are large reptilian creatures of ancient origin and tremendous power. True dragons, including the good metallic dragons and the evil chromatic dragons, are highly intelligent and have innate magic. Also in this category are creatures distantly related to true dragons, but less powerful, less intelligent, and less magical, such as wyverns and pseudodragons.
 Elementals are creatures native to the elemental planes. Some creatures of this type are little more than animate masses of their respective elements, including the creatures simply called elementals. Others have biological forms infused with elemental energy. The races of genies, including djinn and efreet, form the most important civilizations on the elemental planes. Other elemental creatures include azers and invisible stalkers.
 Feyare magical creatures closely tied to the forces of nature. They dwell in twilight groves and misty forests. In some worlds, they are closely tied to the Feywild, also called the Plane of Faerie. Some are also found in the Outer Planes, particularly the planes of Arborea and the Beastlands. Fey include dryads, pixies, and satyrs.
-Fiendsare creatures of wickedness that are native to the Lower Planes. A few are the servants of deities, but many more labor under the leadership of archdevils and demon princes. Evil priests and mages sometimes summon fiends to the material world to do their bidding. If an evil celestial is a rarity, a good fiend is almost inconceivable. Fiends include demons, devils, hell hounds, rakshasas, and yugoloths.
+Fiends are creatures of wickedness that are native to the Lower Planes. A few are the servants of deities, but many more labor under the leadership of archdevils and demon princes. Evil priests and mages sometimes summon fiends to the material world to do their bidding. If an evil celestial is a rarity, a good fiend is almost inconceivable. Fiends include demons, devils, hell hounds, rakshasas, and yugoloths.
 Giants tower over humans and their kind. They are humanlike in shape, though some have multiple heads (ettins) or deformities (fomorians). The six varieties of true giant are hill giants, stone giants, frost giants, fire giants, cloud giants, and storm giants. Besides these, creatures such as ogres and trolls are giants.
 Humanoids are the main peoples of a fantasy gaming world, both civilized and savage, including humans and a tremendous variety of other species. They have language and culture, few if any innate magical abilities (though most humanoids can learn spellcasting), and a bipedal form. The most common humanoid races are the ones most suitable as player characters: humans, dwarves, elves, and halflings. Almost as numerous but far more savage and brutal, and almost uniformly evil, are the races of goblinoids (goblins, hobgoblins, and bugbears), orcs, gnolls, lizardfolk, and kobolds.
 Monstrosities are monsters in the strictest sense-frightening creatures that are not ordinary, not truly natural, and almost never benign. Some are the results of magical experimentation gone awry (such as owlbears), and others are the product of terrible curses (including minotaurs and yuan-ti). They defy categorization, and in some sense serve as a catch-all category for creatures that don’t fit into any other type.
@@ -16558,7 +16558,7 @@ Keen Hearing and Smell.The mastiff has advantage on Wisdom (Perception) checks t
 Actions
 Bite.Melee Weapon Attack:+3 to hit, reach 5 ft., one target.
 Hit: 4 (1d6 + 1) piercing damage. If the target is a creature, it must succeed on a DC 11 Strength saving throw or be knocked prone.
-Mastiffsare impressive hounds prized by humanoids for their loyalty and keen senses. Mastiffs can be trained as guard dogs, hunting dogs, and war dogs. Halflings and other Small humanoids ride them as mounts.
+Mastiffs are impressive hounds prized by humanoids for their loyalty and keen senses. Mastiffs can be trained as guard dogs, hunting dogs, and war dogs. Halflings and other Small humanoids ride them as mounts.
 
 Mule
 Medium beast, unaligned
@@ -17186,7 +17186,7 @@ Actions
 Club. Melee Weapon Attack:
 +2 to hit, reach 5 ft., one target.
 Hit: 2 (1d4) bludgeoning damage.
-Acolytesare junior members of a clergy, usually answerable to a priest. They perform a variety of functions in a temple and are granted minor spellcasting power by their deities.
+Acolytes are junior members of a clergy, usually answerable to a priest. They perform a variety of functions in a temple and are granted minor spellcasting power by their deities.
 
 Archmage
 Medium humanoid (any race), any alignment
@@ -17240,7 +17240,7 @@ on a successful one.
 Light Crossbow. Ranged Weapon Attack:+6 to hit, range 80/320 ft., one target.
 Hit:7 (1d8 + 3) piercing damage, and the target must make a DC 15 Constitution saving throw, taking 24 (7d6) poison damage on a failed save, or half as much damage on a successful one.
 Trained in the use of poison,
-assassinsare remorseless killers who work for nobles, guildmasters, sovereigns, and anyone else who can afford them.
+assassins are remorseless killers who work for nobles, guildmasters, sovereigns, and anyone else who can afford them.
 
 Bandit
 Medium humanoid (any race), any non--lawful alignment
@@ -17364,7 +17364,7 @@ Actions
 Multiattack. The fanatic makes two melee attacks.
 Dagger. Melee or Ranged Weapon Attack:+4 to hit, reach 5 ft. or range 20/60 ft., one creature.
 Hit: 4 (1d4 +2) piercing damage.
-Fanaticsare often part of a cult’s leadership, using their charisma and dogma to influence and prey on those of weak will. Most are interested in personal power above all else.
+Fanatics are often part of a cult’s leadership, using their charisma and dogma to influence and prey on those of weak will. Most are interested in personal power above all else.
 
 Druid
 Medium humanoid (any race), any alignment
@@ -17602,7 +17602,7 @@ Hit:5 (1d6 + 2) bludgeoning damage.
 Heavy Crossbow.Ranged Weapon Attack:
 +2 to hit, range 100/400 ft., one target.
 Hit: 5 (1d10) piercing damage.
-Thugsare ruthless enforcers skilled at intimidation and violence. They work for money and have few scruples.
+Thugs are ruthless enforcers skilled at intimidation and violence. They work for money and have few scruples.
 
 Tribal Warrior
 Medium humanoid (any race), any alignment
@@ -17644,5 +17644,5 @@ Hit:6 (1d6 + 3) piercing damage.
 Heavy Crossbow.Ranged Weapon Attack:
 +3 to hit, range 100/400 ft., one target.
 Hit:6 (1d10 + 1) piercing damage.
-Veteransare professional fighters that take up arms for pay or to protect something they believe in or value. Their ranks include soldiers retired from long service and warriors who never served anyone but
+Veterans are professional fighters that take up arms for pay or to protect something they believe in or value. Their ranks include soldiers retired from long service and warriors who never served anyone but
 themselves.


### PR DESCRIPTION
```diff
- Celestialsare creatures native to the Upper Planes.
+ Celestials are creatures native to the Upper Planes.
```

Note the space separating `Celestialsare` into `Celestials are`.

I did this programmatically via:

```sh
$ perl -i -lpe 's/^(\w+s)are /$1 are /' SRD5.1-CCBY4.0License-TT.txt
```

To verify the correctness of this diff, I suggest ignoring whitespace
changes on it. It will appear empty, because the only thing this commit
does is adds spaces after a few words:

* `Celestialsare` -> `Celestials are`
* `Celestialsare` -> `Celestials are`
* `Constructsare` -> `Constructs are`
* `Dragonsare` -> `Dragons are`
* `Fiendsare` -> `Fiends are`
* `Mastiffsare` -> `Mastiffs are`
* `Acolytesare` -> `Acolytes are`
* `assassinsare` -> `assassins are`
* `Fanaticsare` -> `Fanatics are`
* `Thugsare` -> `Thugs are`
* `Veteransare` -> `Veterans are`
